### PR TITLE
Fix broken link and syntax errors in docs

### DIFF
--- a/web/_documentation/examples/distributed-authentication.md
+++ b/web/_documentation/examples/distributed-authentication.md
@@ -15,7 +15,7 @@ authentication. The idea is that, after performing the authentication protocol, 
 
 ```choral
 public class AuthResult@( A, B ) extends 
-  BiPair@( A, B )< Optional@A< AuthToken >, Optional@B< AuthToken > > { 
+  BiPair@( A, B )< Optional< AuthToken >, Optional< AuthToken > > { 
   
   public AuthResult( AuthToken@A t1, AuthToken@B t2 ){ 
     super( Optional@A.< AuthToken >of( t1 ), Optional@B.< AuthToken >of( t2 ) ); 
@@ -62,16 +62,16 @@ public class DistAuth@( Client, Service, IP ){
     >> ClientRegistry@IP::check; 
 
     if ( valid ) {
-      ch_Client_IP.< EnumBoolean >select( AuthBranch@IP.OK );
-      ch_Service_IP.< EnumBoolean >select( AuthBranch@IP.OK );
+      ch_Client_IP.< EnumBoolean >select( EnumBoolean@IP.True );
+      ch_Service_IP.< EnumBoolean >select( EnumBoolean@IP.True );
       AuthToken@IP t = AuthToken@IP.create();
       return new AuthResult@( Client, Service )( 
         ch_Client_IP.<AuthToken>com( t ), 
         ch_Service_IP.<AuthToken>com( t )
       );
     } else {
-      ch_Client_IP.< EnumBoolean >select( AuthBranch@IP.KO );
-      ch_Service_IP.< EnumBoolean >select( AuthBranch@IP.KO );
+      ch_Client_IP.< EnumBoolean >select( EnumBoolean@IP.False );
+      ch_Service_IP.< EnumBoolean >select( EnumBoolean@IP.False );
       return new AuthResult@( Client, Service )();
     }
   }

--- a/web/documentation.md
+++ b/web/documentation.md
@@ -22,7 +22,7 @@ The tutorials assume that you're familiar with Java or a similar language.
 Since Choral's aim is to produce "idiomatic" Java libraries, Choral incorporates many features from the Java language, like classes, interfaces, generics, inheritance, and method overloading.[^lambda]
 
 <div markdown=0 class="text-center">
-<a href="/documentation/basics/hello_roles.html">
+<a href="/documentation/basics/hello-roles.html">
 <div class="btn btn-outline-info btn-lg">
 First tutorial: Hello Roles
 </div></a>


### PR DESCRIPTION
When reading through the docs and trying to follow the code examples, I found a broken link and some syntax errors.